### PR TITLE
Test log fix

### DIFF
--- a/bob/bob-test.scm
+++ b/bob/bob-test.scm
@@ -1,6 +1,8 @@
 ;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
 
+(module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
+
 ;; Require bob impl
 (add-to-load-path (dirname (current-filename)))
 (use-modules (bob))

--- a/bob/bob-test.scm
+++ b/bob/bob-test.scm
@@ -1,6 +1,7 @@
 ;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
 
+;; Suppress log file output. To write logs, comment out the following line:
 (module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
 
 ;; Require bob impl

--- a/difference-of-squares/difference-of-squares-test.scm
+++ b/difference-of-squares/difference-of-squares-test.scm
@@ -1,5 +1,7 @@
 ;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
+
+;; Suppress log file output. To write logs, comment out the following line:
 (module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
 
 ;; Require module

--- a/difference-of-squares/difference-of-squares-test.scm
+++ b/difference-of-squares/difference-of-squares-test.scm
@@ -1,5 +1,6 @@
 ;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
+(module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
 
 ;; Require module
 (add-to-load-path (dirname (current-filename)))

--- a/leap/leap-test.scm
+++ b/leap/leap-test.scm
@@ -1,5 +1,7 @@
 ;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
+
+;; Suppress log file output. To write logs, comment out the following line:
 (module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
 
 ;; Require module

--- a/leap/leap-test.scm
+++ b/leap/leap-test.scm
@@ -1,5 +1,6 @@
 ;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
+(module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
 
 ;; Require module
 (add-to-load-path (dirname (current-filename)))

--- a/nucleotide-count/nucleotide-count-test.scm
+++ b/nucleotide-count/nucleotide-count-test.scm
@@ -1,5 +1,7 @@
 ;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
+
+;; Suppress log file output. To write logs, comment out the following line:
 (module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
 
 (add-to-load-path (dirname (current-filename)))

--- a/nucleotide-count/nucleotide-count-test.scm
+++ b/nucleotide-count/nucleotide-count-test.scm
@@ -1,4 +1,6 @@
+;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
+(module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
 
 (add-to-load-path (dirname (current-filename)))
 (use-modules (nucleotide-count))

--- a/point-mutations/point-mutations-test.scm
+++ b/point-mutations/point-mutations-test.scm
@@ -1,5 +1,7 @@
 ;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
+
+;; Suppress log file output. To write logs, comment out the following line:
 (module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
 
 (add-to-load-path (dirname (current-filename)))

--- a/point-mutations/point-mutations-test.scm
+++ b/point-mutations/point-mutations-test.scm
@@ -1,4 +1,6 @@
+;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
+(module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
 
 (add-to-load-path (dirname (current-filename)))
 (use-modules (point-mutations))

--- a/raindrops/raindrops-test.scm
+++ b/raindrops/raindrops-test.scm
@@ -1,5 +1,7 @@
 ;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
+
+;; Suppress log file output. To write logs, comment out the following line:
 (module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
 
 (add-to-load-path (dirname (current-filename)))

--- a/raindrops/raindrops-test.scm
+++ b/raindrops/raindrops-test.scm
@@ -1,4 +1,6 @@
+;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
+(module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
 
 (add-to-load-path (dirname (current-filename)))
 

--- a/rna-transcription/rna-transcription-test.scm
+++ b/rna-transcription/rna-transcription-test.scm
@@ -1,6 +1,7 @@
 ;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
 
+;; Suppress log file output. To write logs, comment out the following line:
 (module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
 
 (add-to-load-path (dirname (current-filename)))

--- a/rna-transcription/rna-transcription-test.scm
+++ b/rna-transcription/rna-transcription-test.scm
@@ -1,4 +1,7 @@
+;; Load SRFI-64 lightweight testing specification
 (use-modules (srfi srfi-64))
+
+(module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
 
 (add-to-load-path (dirname (current-filename)))
 (use-modules (dna))


### PR DESCRIPTION
Suppress log output by default, redefining `test-log-output` to `#f` in `srfi-64`.

Should take care of the issue with 92M log files in #12 