### PR TITLE
Add grains exercise

### DIFF
--- a/grains/example.scm
+++ b/grains/example.scm
@@ -1,0 +1,10 @@
+(define-module (grains)
+  #:export (square total))
+
+(use-modules (srfi srfi-1))
+
+(define (square n)
+  (expt 2 (1- n)))
+
+(define (total)
+  (reduce + 0 (map square (iota 64 1))))

--- a/grains/grains-test.scm
+++ b/grains/grains-test.scm
@@ -1,0 +1,47 @@
+;; Load SRFI-64 lightweight testing specification
+ (use-modules (srfi srfi-64))
+
+ ;; Suppress log file output. To write logs, comment out the following line:
+ (module-define! (resolve-module '(srfi srfi-64)) 'test-log-to-file #f)
+
+ ;; Require module
+ (add-to-load-path (dirname (current-filename)))
+ (use-modules (grains))
+
+ (test-begin "grains")
+
+(test-eqv "square 1"
+          1
+          (square 1))
+
+(test-eqv "square 2"
+          2
+          (square 2))
+
+(test-eqv "square 3"
+          4
+          (square 3))
+
+(test-eqv "square 4"
+          8
+          (square 4))
+
+(test-eqv "square 16"
+          32768
+          (square 16))
+
+(test-eqv "square 32"
+          2147483648
+          (square 32))
+
+(test-eqv "square 64"
+          9223372036854775808
+          (square 64))
+
+(test-eqv "total grains"
+          18446744073709551615
+          (total))
+
+ ;; Tests go here
+
+ (test-end "grains")

--- a/grains/grains.scm
+++ b/grains/grains.scm
@@ -1,0 +1,10 @@
+(define-module (grains)
+  #:export (square total))
+
+(use-modules (srfi srfi-1))
+
+(define (square n)
+  )
+
+(define (total)
+  )


### PR DESCRIPTION
moving into territory where it just makes sense to use SRFI's, so I left `(use-modules (srfi srfi-1))` in the template... these are going to be common, I might update SETUP.md to explain them to newbs, they're sortof-stdlib-sortof-extra, like having to `require 'net/http'` in Ruby... but anyhow... exercise number 10! woo!