### PR TITLE
Use #:autoload directive in define-module instead of use-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,20 @@ Exercism exercises in the Scheme Programming Language
 
 ## Setup
 
-You'll need a vaguely [R6RS](http://www.r6rs.org/)-compliant Scheme implementation. As of this writing, the exercises are being developed primarily in [Guile Scheme](http://www.gnu.org/software/guile/), but the tests are using [SFRI-64](http://srfi.schemers.org/srfi-64/srfi-64.html), and so should (hopefully) be rather implementation-agnostic.
+You'll need a vaguely [R6RS](http://www.r6rs.org/)-compliant Scheme implementation. As of this writing, the exercises are being developed in [Guile Scheme](http://www.gnu.org/software/guile/), but the tests are using [SFRI-64](http://srfi.schemers.org/srfi-64/srfi-64.html), and so should (hopefully) be rather implementation-agnostic.
 
 ## Working on Problems
 
 Each problem should have a test suite and an example solution, as well as a stub file for the solution declaring the module and exports. The example solution should be named `example.scm`.
 
+## Dependencies
+
+Try to avoid external dependencies. It will often be necessary to use various
+modules included in the Guile distribution, such as the ice-9 and srfi
+collections. When using these modules in exercises/examples, please use the
+`#:autoload` directive in `(define-module)` rather than `(use-modules ...)` for
+the sake of consistency, and to give a clue which functions are being relied
+upon.
 
 ## Contributing Guide
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,7 +1,13 @@
 No additional dependencies should be required.
 
+Sometimes module functions will be loaded that are useful to the problem case.
+You'll see them in the `define-package` macro at the top of the source file,
+thus: `#:autoload (mod submod) (function0 function1)`. The curious can read
+about included modules [here][0].
+
 If you need help getting set up, see [Getting Started With Scheme][1]
 in the [Exercism.io Help][2] pages.
 
+[0]: https://www.gnu.org/software/guile/docs/docs-2.0/guile-ref/Included-Guile-Modules.html
 [1]: http://help.exercism.io/getting-started-with-scheme.html
 [2]: http://help.exercism.io

--- a/grains/example.scm
+++ b/grains/example.scm
@@ -1,7 +1,6 @@
 (define-module (grains)
-  #:export (square total))
-
-(use-modules (srfi srfi-1))
+  #:export (square total)
+  #:autoload (srfi srfi-1) (iota))
 
 (define (square n)
   (expt 2 (1- n)))

--- a/grains/grains.scm
+++ b/grains/grains.scm
@@ -1,7 +1,6 @@
 (define-module (grains)
-  #:export (square total))
-
-(use-modules (srfi srfi-1))
+  #:export (square total)
+  #:autoload (srfi srfi-1) (iota))
 
 (define (square n)
   )

--- a/phone-number/example.scm
+++ b/phone-number/example.scm
@@ -1,7 +1,6 @@
 (define-module (phone-number)
-  #:export (numbers area-code pprint))
-
-(use-modules (ice-9 format))
+  #:export (numbers area-code pprint)
+  #:autoload (ice-9 format) (format))
 
 
 (define (strip-non-digits str)

--- a/phone-number/phone-number.scm
+++ b/phone-number/phone-number.scm
@@ -1,7 +1,8 @@
 (define-module (phone-number)
-  #:export (numbers area-code pprint))
+  #:export (numbers area-code pprint)
+  #:autoload (ice-9 format) (format))
 
-(use-modules (ice-9 format))
+
 
 
 


### PR DESCRIPTION
Noticed inconsistency in how modules were being included in example/exercise stub... when a package is being defined, #:autoload is preferred as it pulls in named fns and avoids loading an entire module at runtime.

As per discussion in #20 I'll update teh docs where appropriate (I guess the README in this repo, for exercise contributors, and SETUP to explain what's going on to users?) to explain what's going on there.