### PR TITLE
add instructions for installation from source on ubuntu

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -25,6 +25,27 @@ Arch:
 pacman -S guile
 ```
 
+Ubuntu:
+
+In ubuntu 14.04 the packages for guile are missing modules that prevent the
+tests from running.
+Guile can be installed from source under your home directory by following the
+instructions below.
+```
+sudo apt-get install libltdl-dev libunistring-dev libgc-dev libmpd-dev libgmp3-dev libffi-dev
+cd $HOME/Downloads/
+wget ftp://ftp.gnu.org/gnu/guile/guile-2.0.11.tar.gz
+tar -zxvf guile-2.0.11.tar.gz
+cd guile-2.0.11/
+./configure --prefix=$HOME/lib/guile
+make
+make install
+if [ ! -d $HOME/bin ]; then mkdir $HOME/bin; fi
+ln -s $HOME/lib/guile/bin/guile $HOME/bin/guile
+```
+After installation is complete you will need to log out and back into ubuntu
+in order for the path to be set on your /home/bin directory.
+
 **Windows**
 
 Guile can theoretically be compiled from source under [Cygwin](https://www.cygwin.com/), but as with


### PR DESCRIPTION
Fix for #30 
I have submitted the pull request to the source of the new documentation as, that is where I raised the issue, and so seems tidier.
The instructions are quite brief to try and match the style of the existing document.
However, I would be happy to supply more information on what the commands do, if it was felt that this was better.