### PR TITLE
Remove license info from README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2014 Katrina Owen, _@kytrinyx.com
+Copyright (c) 2017 Exercism, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.org
+++ b/README.org
@@ -32,12 +32,6 @@ upon.
 
 Please see the [[https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data][contributing guide]]
 
-** License
-
-The MIT License (MIT)
-
-Copyright (c) 2014 Katrina Owen, [[mailto:_@kytrinyx.com][_@kytrinyx.com]]
-
 ** Scheme icon
 
 The Scheme logo was created by [[Matthias.f at en.wikipedia][https://en.wikipedia.org/wiki/User:Matthias.f]] and released under the Creative Commons Attribution-Share Alike 3.0 Unported license.


### PR DESCRIPTION
We don't need the duplication, especially now that the GitHub interface shows the
license information on the main page of the repository when it can be detected
directly from the LICENSE file.

This also updates the license file to reassign copyright to the Exercism legal entity.